### PR TITLE
Use double quotes in rtorrent script

### DIFF
--- a/docs/basics/daemon.md
+++ b/docs/basics/daemon.md
@@ -178,7 +178,7 @@ For rTorrent, you'll have to edit your `.rtorrent.rc` file.
 
     ```shell
     #!/bin/sh
-    curl -XPOST http://localhost:2468/api/webhook --data-urlencode 'name=$1'
+    curl -XPOST http://localhost:2468/api/webhook --data-urlencode "name=$1"
     ```
 
 :::tip Docker users


### PR DESCRIPTION
When I copy/pasted the script content, cross-seed did not receive the proper name. The solutio was to use double quotes `"`.