### PR TITLE
Fix `--output-dir` note for Docker users.

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -240,8 +240,8 @@ rTorrent has access to this path also.
 
 :::caution Docker users
 
-Leave the `outputDir` as `/output` and use Docker to map your directory to
-`/output`.
+Leave the `outputDir` as `/cross-seeds` and use Docker to map your directory to
+`/cross-seeds`.
 
 :::
 


### PR DESCRIPTION
New user here, thank you for the great package @mmgoodnow!

This is just a small PR to fix a note to Docker users concerning the use of `--output-dir`. It seems like the output location in the container used to be `/output` but I believe it is now `/cross-seeds`.