### PR TITLE
fix(daemon): fix rtorrent download.finished config

### DIFF
--- a/docs/basics/daemon.md
+++ b/docs/basics/daemon.md
@@ -247,10 +247,10 @@ For rTorrent, you'll have to edit your `.rtorrent.rc` file.
     chmod +x rtorrent-cross-seed.sh
     ```
 
-5.  Run the following commands (this will add variables and tell rTorrent to execute your script:
+5.  Run the following commands (this will add variables and tell rTorrent to execute your script):
     ```shell
     echo 'method.insert=d.data_path,simple,"if=(d.is_multi_file),(cat,(d.directory),/),(cat,(d.directory),/,(d.name))"' >> .rtorrent.rc
-    echo 'method.set_key=event.download.finished,cross_seed,"execute={'`pwd`/rtorrent-cross-seed.sh',$d.name=,$d.hash=,$d.data_path}"' >> .rtorrent.rc
+    echo 'method.set_key=event.download.finished,cross_seed,"execute={'`pwd`/rtorrent-cross-seed.sh',$d.name=,$d.hash=,$d.data_path=}"' >> .rtorrent.rc
     ```
 
 ### qBittorrent


### PR DESCRIPTION
This commit fixes the example `.rtorrent.rc` configuration for the `event.download.finished` that invokes a cross-seed script when a download completes.

The example configuration in the documentation is incorrect because it is missing the equals sign on the last argument. This results in `rTorrent` never invoking the cross seed script on the download finished event. It's also difficult to discover, as the error didn't make it to my log, only appearing in the curses console for a brief second.

Also, I fixed an unclosed parenthesis in the same area.