### PR TITLE
update(unraid/daemon): improvements to unraid container documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.yarn
 .frontmatter/database/pinnedItemsDb.json
 .frontmatter/database/taxonomyDb.json
 frontmatter.json

--- a/docs/basics/daemon.md
+++ b/docs/basics/daemon.md
@@ -43,6 +43,8 @@ that you **do not expose its port to untrusted networks (such as the Internet).*
 
 If you are running `cross-seed` on Unraid, it runs in [daemon mode by default](../tutorials/unraid.md#automationscheduling) and no changes are needed.
 
+See [this screenshot and instructions](../tutorials/unraid.md#screenshot) for details on changing the `cross-seed` command
+
 :::
 
 ## Running the daemon continuously

--- a/docs/basics/daemon.md
+++ b/docs/basics/daemon.md
@@ -98,9 +98,11 @@ docker logs cross-seed # view the logs
 
 ### Unraid
 
-If you are running `cross-seed` on Unraid, it runs in [daemon mode by default](../tutorials/unraid.md#automationscheduling) and no changes are needed.
+If you are running `cross-seed` on Unraid you should have installed the "Community App" from ambipro's repository, this is our official container.
 
-See [this screenshot and instructions](../tutorials/unraid.md#screenshot) for details on changing the `cross-seed` command.
+Be default, the [container runs in daemon mode](../tutorials/unraid.md#automationscheduling) and no changes are needed.
+
+We recommend you head over to the [Unraid Tutorial](../tutorials/unraid.md) for specifics and documentation for the container.
 
 ### `systemd` (Linux)
 

--- a/docs/basics/daemon.md
+++ b/docs/basics/daemon.md
@@ -39,6 +39,12 @@ that you **do not expose its port to untrusted networks (such as the Internet).*
 
 :::
 
+:::info Unraid
+
+If you are running `cross-seed` on Unraid, it runs in [daemon mode by default](../tutorials/unraid.md#automationscheduling) and no changes are needed.
+
+:::
+
 ## Running the daemon continuously
 
 The easiest way to run the daemon is just to leave a terminal open after running

--- a/docs/basics/daemon.md
+++ b/docs/basics/daemon.md
@@ -39,14 +39,6 @@ that you **do not expose its port to untrusted networks (such as the Internet).*
 
 :::
 
-:::info Unraid
-
-If you are running `cross-seed` on Unraid, it runs in [daemon mode by default](../tutorials/unraid.md#automationscheduling) and no changes are needed.
-
-See [this screenshot and instructions](../tutorials/unraid.md#screenshot) for details on changing the `cross-seed` command
-
-:::
-
 ## Running the daemon continuously
 
 The easiest way to run the daemon is just to leave a terminal open after running
@@ -65,6 +57,7 @@ However, that's not very sustainable.
 Below are a few ways you can set up `cross-seed daemon` to run on its own:
 
 - [Docker](#docker)
+- [Unraid](#unraid)
 - [`systemd`](#systemd-linux)
 - [`screen`](#screen)
 
@@ -102,6 +95,12 @@ docker stop cross-seed # Stop the daemon
 docker restart cross-seed # Restart the daemon
 docker logs cross-seed # view the logs
 ```
+
+### Unraid
+
+If you are running `cross-seed` on Unraid, it runs in [daemon mode by default](../tutorials/unraid.md#automationscheduling) and no changes are needed.
+
+See [this screenshot and instructions](../tutorials/unraid.md#screenshot) for details on changing the `cross-seed` command.
 
 ### `systemd` (Linux)
 

--- a/docs/tutorials/unraid.md
+++ b/docs/tutorials/unraid.md
@@ -5,9 +5,9 @@ title: Unraid
 
 ## Installation
 
-To install in unRAID, the easiest setup will be to use the
+To install in Unraid, the easiest setup will be to use the
 [Community Applications](https://forums.unraid.net/topic/38582-plug-in-community-applications/)
-app (Apps section in the unRAID WebUI). Go to the **Apps** tab and search for `cross-seed`.
+app (Apps section in the Unraid WebUI). Go to the **Apps** tab and search for `cross-seed`.
 We have an official container now, which is under "ambipro's Repository". Click on the "Install"
 button. This will take you to the template configuration.
 
@@ -54,7 +54,13 @@ Below is a screenshot of what your Docker container configuration might look
 like. Now, you can try starting the Docker container and editing the resulting
 configuration file in the next step.
 
-![screenshot-cross-seed](https://user-images.githubusercontent.com/2813049/147599328-6032688e-45e4-43cf-87f6-a070829e1a1b.png)
+![screenshot-cross-seed](https://github.com/cross-seed/cross-seed.org/assets/123845855/2ce0b912-e341-4622-b0a1-8dcd18557730)
+
+:::tip
+
+In the top right if you enable "Advanced View" it will reveal the `Post Argument` field, this can be changed from `daemon` to `search` (for example) to run the search command.
+
+:::
 
 You can start the container to create the config file path.
 


### PR DESCRIPTION
adds a new "info" block to the daemon mode page calling out that daemon mode is set on unraid by default with a link to the unraid page