### PR TITLE
update(options/excludeRecentSearch): add note about failed search behavior

### DIFF
--- a/docs/basics/options.md
+++ b/docs/basics/options.md
@@ -642,7 +642,8 @@ excludeOlder: "0s",
 When running a search, this option excludes anything that has been searched
 more recently than this long ago. This option is only relevant in
 `search` mode or in `daemon` mode with [`searchCadence`](#searchcadence) turned
-on.
+on. Previous searches that failed due to a timeout or other error will not be
+exluded.
 
 #### `excludeRecentSearch` Examples (CLI)
 

--- a/docs/basics/options.md
+++ b/docs/basics/options.md
@@ -642,8 +642,12 @@ excludeOlder: "0s",
 When running a search, this option excludes anything that has been searched
 more recently than this long ago. This option is only relevant in
 `search` mode or in `daemon` mode with [`searchCadence`](#searchcadence) turned
-on. Previous searches that failed due to a timeout or other error will not be
-exluded.
+on.
+
+:::note
+
+Searches that failed on specific trackers (for example - due to timeout or rate-limiting) will not be marked as having been searched, and thus will not be excluded by this setting for those specific trackers on the next run.
+:::
 
 #### `excludeRecentSearch` Examples (CLI)
 


### PR DESCRIPTION
Make it a little more obvious that previously failed searched are not also excluded.