### PR TITLE
add(faq): specific caution regarding daily shows and risky matching

### DIFF
--- a/docs/basics/faq-troubleshooting.md
+++ b/docs/basics/faq-troubleshooting.md
@@ -223,6 +223,11 @@ Using [`risky`](./options.md#matchmode) matching will match torrents for snatchi
 Using [`safe`](./options.md#matchmode) matching will match torrents for snatching based on the size and require that the release groups match and compare them, requiring file structure to match.
 :::
 
+:::caution
+There are some TV shows that do not have season packs, such as Jeopardy, talk shows and similar, with their naming including dates, rather than SeasonEpisode. Searching with `includeSingleEpisodes` and using `risky` on these files can result in *hundreds of torrents files being downloaded* so as to data match, *an individual episode*.
+Remember, this would occur on just one (torrent) search, within the entire (all data) search.
+:::
+
 ---
 
 It is highly recommended to utilize [`excludeOlder` and `excludeRecentSearch`](./daemon.md#set-up-periodic-searches). Both of these are covered [here](./daemon.md#set-up-periodic-searches) as well as on the [options page](./options.md#excludeolder).


### PR DESCRIPTION
Daily shows with date naming, *My.Show.XXXX.XX.XX.1080p.mkv* do not have the conventional *My.Show.S01.E01.1080p.mkv* naming and are rarely, if ever, packed into seasons.

This means that there are configurable options where 20+ years of individual episode torrents are downloaded to run size based data matching. 

Add some specific caution to the FAQ, so that blame can be passed as needed.