### PR TITLE
fix(options): replace incorrect --delugerpc-url with --deluge-rpc-url

### DIFF
--- a/docs/basics/options.md
+++ b/docs/basics/options.md
@@ -1076,7 +1076,7 @@ transmissionRpcUrl: "http://username:password@localhost:9091/transmission/rpc",
 
 | Config file name | CLI short form | CLI long form           | Format | Default |
 | ---------------- | -------------- | ----------------------- | ------ | ------- |
-| `delugeRpcUrl`   |                | `--delugerpc-url <url>` | URL    |         |
+| `delugeRpcUrl`   |                | `--deluge-rpc-url <url>` | URL    |         |
 
 The url of your **Deluge** JSON-RPC Interface. Only relevant with
 [Injection](../tutorials/injection).
@@ -1090,8 +1090,8 @@ The url of your **Deluge** JSON-RPC Interface. Only relevant with
 #### `delugeRpcUrl` Examples (CLI)
 
 ```shell
-cross-seed search --delugerpc-url http://deluge:8112/json
-cross-seed search --delugerpc-url http://:pass@localhost:8112/json
+cross-seed search --deluge-rpc-url http://deluge:8112/json
+cross-seed search --deluge-rpc-url http://:pass@localhost:8112/json
 ```
 
 #### `delugeRpcUrl` Examples (Config file)


### PR DESCRIPTION
The CLI option for `delugeRpcUrl` should be `--deluge-rpc-url` not `--delugerpc-url`

See: https://github.com/cross-seed/cross-seed/blob/06c5f2b93f8d086df74ce503cbef51199dc6f21b/src/cmd.ts#L229

Docs link: https://www.cross-seed.org/docs/basics/options#delugerpcurl