### PR TITLE
fix(options): replace incorrect --tranmissionrpc-url with --transmission-rpc-url

### DIFF
--- a/docs/basics/options.md
+++ b/docs/basics/options.md
@@ -1046,7 +1046,7 @@ qbittorrentUrl: "http://user:pass@localhost:8080",
 
 | Config file name     | CLI short form | CLI long form                 | Format | Default |
 | -------------------- | -------------- | ----------------------------- | ------ | ------- |
-| `transmissionRpcUrl` |                | `--transmissionrpc-url <url>` | URL    |         |
+| `transmissionRpcUrl` |                | `--transmission-rpc-url <url>` | URL    |         |
 
 The url of your **Transmission** RPC Interface. Only relevant with
 [Injection](../tutorials/injection).
@@ -1060,8 +1060,8 @@ The url of your **Transmission** RPC Interface. Only relevant with
 #### `transmissionRpcUrl` Examples (CLI)
 
 ```shell
-cross-seed search --transmissionrpc-url http://transmission:8080/transmission/rpc
-cross-seed search --transmissionrpc-url http://user:pass@localhost:8080
+cross-seed search --transmission-rpc-url http://transmission:8080/transmission/rpc
+cross-seed search --transmission-rpc-url http://user:pass@localhost:8080
 ```
 
 #### `transmissionRpcUrl` Examples (Config file)


### PR DESCRIPTION
Similar to #54 

The CLI option for tranmissionRpcUrl should be `--transmission-rpc-url` not `--transmissionrpc-url`

I've not actually tested this but it seems to be the case according to:

https://github.com/cross-seed/cross-seed/blob/06c5f2b93f8d086df74ce503cbef51199dc6f21b/src/cmd.ts#L224
