### PR TITLE
fix(options): Fix seasonFromEpisodes undefined

### DIFF
--- a/docs/basics/options.md
+++ b/docs/basics/options.md
@@ -785,8 +785,8 @@ includeSingleEpisodes: false,
 `cross-seed` will also aggregate individual episodes into season packs for
 searching (when applicable) or to match with season packs from rss/announce.
 This will only match season packs where you have at least the specified ratio of
-episodes. `undefined` or `null` disables this feature. If enabled, values below
-1 requires matchMode [partial](#matchmode).
+episodes. `null` disables this feature. If enabled, values below 1 requires
+matchMode [partial](#matchmode).
 
 :::tip
 


### PR DESCRIPTION
Fix docs to clarify that only `null` disables `seasonFromEpisodes`. Since it is set using [`fallback`](https://github.com/cross-seed/cross-seed/blob/19054f3b9424e6850c4ddc06c4fbeab091b3f488/src/cmd.ts#L195), `undefined` actually sets it to `1`.