### PR TITLE
Include ruTorrent way of accessing rTorrent

### DIFF
--- a/docs/basics/options.md
+++ b/docs/basics/options.md
@@ -1098,7 +1098,7 @@ The url of your **Transmission** RPC Interface prefixed with `transmission`:
 #### `rtorrent`
 
 The url of your **rTorrent** XMLRPC interface prefixed with `rtorrent`:
-`rtorrent:http://user:pass@localhost:8080/RPC2`
+`rtorrent:http://user:pass@localhost:8080/RPC2` or `rtorrent:http://user:pass@localhost:8080/rutorrent/plugins/httprpc/action.php`
 
 :::info
 


### PR DESCRIPTION
A lot of rTorrent installs don't have (external) access to the RPC2 interface. It works perfectly fine to use ruTorrent's RPC plugin as a replacement, but not many people know that. Adding it here might show some people they can use cross-seed even if they don't have a /RPC2 endpoint available on their server.