### PR TITLE
Update triggering-searches.md

### DIFF
--- a/docs/tutorials/triggering-searches.md
+++ b/docs/tutorials/triggering-searches.md
@@ -101,16 +101,8 @@ Use the webhook command with `-d "includeSingleEpisodes=true"` while keeping
 
     ```shell
     #!/bin/sh
-    curl -XPOST <BASE_URL>/api/webhook?apikey=<API_KEY> -d "infoHash=$2" -d "includeSingleEpisodes=true"
+    /usr/bin/curl -s <BASE_URL>:2468/api/webhook?apikey=<API_KEY> -d "infoHash=$1" -d "includeSingleEpisodes=true" > /dev/null 2>&1 &
     ```
-
-    OR
-
-    ```shell
-    #!/bin/sh
-    curl -XPOST <BASE_URL>/api/webhook?apikey=<API_KEY> -d "infoHash=$2"
-    ```
-
 2. Make it executable:
     ```shell
     chmod +x rtorrent-cross-seed.sh
@@ -118,7 +110,7 @@ Use the webhook command with `-d "includeSingleEpisodes=true"` while keeping
 3. Add to `.rtorrent.rc`:
     ```shell
     echo 'method.insert=d.data_path,simple,"if=(d.is_multi_file),(cat,(d.directory),/),(cat,(d.directory),/,(d.name))"' >> .rtorrent.rc
-    echo 'method.set_key=event.download.finished,cross_seed,"execute={'`pwd`/rtorrent-cross-seed.sh',$d.name=,$d.hash=,$d.data_path=}"' >> .rtorrent.rc
+    echo 'method.set_key=event.download.finished,cross_seed,"execute={'`pwd`/rtorrent-cross-seed.sh',$d.hash=}"' >> .rtorrent.rc
     ```
 4. Restart rTorrent.
 


### PR DESCRIPTION
The original approach did **not** work when copying and pasting directly from the manual page - I had to modify how rTorrent triggers the cross-seed webhook.

rTorrent communicates via XML-RPC, and when a script is executed through `event.download.finished`, it captures the script’s output. If that output is not valid XML-RPC (as is the case with typical HTTP responses), it can cause the XML-RPC parser to fail, resulting in rTorrent becoming unresponsive and displaying a "Bad response" error.

Additionally, it is not necessary to pass `$d.name=` and `$d.data_path=`, the download hash alone is sufficient.

Recommended solution:
* Use `/usr/bin/curl -s` in your script to enable silent mode and suppress output.
* Execute the HTTP call asynchronously (e.g., by appending `&`) to prevent rTorrent from waiting for a response.

This solution has been tested and confirmed to work reliably.