### PR TITLE
Add a warning when using a custom CA certificate for Radarr and Sonarr

### DIFF
--- a/docs/basics/options.md
+++ b/docs/basics/options.md
@@ -182,6 +182,12 @@ sonarr: ["https://sonarr/?apikey=12345"],
 sonarr: ["http://sonarr:8989/?apikey=12345","http://sonarr4k:8990/?apikey=12345"],
 ```
 
+:::warning NOTICE
+
+If you are using a secure connection (HTTPS) to Sonarr and you are using a certificate signed by a custom authority, make sure that the environment variable [`NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#node_extra_ca_certsfile) is set and contains the path to a file containing the root certificate of the custom authority.
+
+:::
+
 ### `radarr`
 
 | Config File Name | CLI Short Form | CLI Long Form       | Format     | Config Default | Fallback |
@@ -217,6 +223,12 @@ radarr: ["https://radarr/?apikey=12345"],
 
 radarr: ["http://radarr:7878/?apikey=12345","https://radarr4k:7879/?apikey=12345"],
 ```
+
+:::warning NOTICE
+
+If you are using a secure connection (HTTPS) to Radarr and you are using a certificate signed by a custom authority, make sure that the environment variable [`NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#node_extra_ca_certsfile) is set and contains the path to a file containing the root certificate of the custom authority.
+
+:::
 
 ### `useClientTorrents`
 


### PR DESCRIPTION
I had a lot of trouble getting cross-seed to work with Sonarr and Radarr, so I thought it would be helpful to the community to add how I solved this problem to the documentation.

My Radarr and Sonarr instances are not on the same server as cross-seed, so I use an HTTPS connection and a personal domain name to access them. I also have an internal certificate authority that was used to generate the Radarr and Sonarr certificates.

The problem was difficult to solve because there was nothing in the logs, even in DEBUG mode:
```
2026-02-03 14:20:16.682 error: Attempt 1/6 failed, retrying in 60s: Could not contact Sonarr at https://sonarr.example.com/?apikey=[REDACTED]
2026-02-03 14:20:16.683 debug: Could not contact Sonarr at https://sonarr.example.com/?apikey=[REDACTED]
```

Perhaps it would be wise to add more information when there is an HTTPS connection error to Radarr and Sonarr.

Note that my Torrent client (qBittorrent) and Torznab (Prowlarr) are on the same server as cross-seed, so I didn't use an HTTPS connection. But it's possible that the problem I encountered with Sonarr and Radarr could also occur, so it may be necessary to include a more general warning. Please advise.